### PR TITLE
Add SMSala notification provider

### DIFF
--- a/server/notification-providers/smsala.js
+++ b/server/notification-providers/smsala.js
@@ -1,0 +1,32 @@
+const NotificationProvider = require("./notification-provider");
+const axios = require("axios");
+
+class SMSala extends NotificationProvider {
+    name = "SMSala";
+
+    /**
+     * @inheritdoc
+     */
+    async send(notification, msg, monitorJSON = null, heartbeatJSON = null) {
+        const okMsg = "Sent Successfully.";
+        const url = "https://api2.smsala.com/SendSmsV2";
+
+        try {
+            let params = new URLSearchParams();
+            params.append("apiToken", notification.smsalaApiToken);
+            params.append("messageType", notification.smsalaMessageType || "1");
+            params.append("messageEncoding", notification.smsalaMessageEncoding || "1");
+            params.append("destinationAddress", notification.smsalaTo);
+            params.append("sourceAddress", notification.smsalaFrom);
+            params.append("messageText", msg);
+
+            await axios.get(`${url}?${params.toString()}`);
+
+            return okMsg;
+        } catch (error) {
+            this.throwGeneralAxiosError(error);
+        }
+    }
+}
+
+module.exports = SMSala;

--- a/server/notification.js
+++ b/server/notification.js
@@ -76,6 +76,7 @@ const Wpush = require("./notification-providers/wpush");
 const SendGrid = require("./notification-providers/send-grid");
 const YZJ = require("./notification-providers/yzj");
 const SMSPlanet = require("./notification-providers/sms-planet");
+const SMSala = require("./notification-providers/smsala");
 const SpugPush = require("./notification-providers/spugpush");
 
 class Notification {
@@ -169,6 +170,7 @@ class Notification {
             new SendGrid(),
             new YZJ(),
             new SMSPlanet(),
+            new SMSala(),
             new SpugPush(),
             new Notifery(),
         ];

--- a/src/components/NotificationDialog.vue
+++ b/src/components/NotificationDialog.vue
@@ -169,7 +169,8 @@ export default {
                 "gtxmessaging": "GtxMessaging",
                 "Cellsynt": "Cellsynt",
                 "SendGrid": "SendGrid",
-                "notifery": "Notifery"
+                "notifery": "Notifery",
+                "SMSala": "SMSala"
             };
 
             // Put notifications here if it's not supported in most regions or its documentation is not in English

--- a/src/components/notifications/SMSala.vue
+++ b/src/components/notifications/SMSala.vue
@@ -1,0 +1,41 @@
+<template>
+    <div class="mb-3">
+        <label for="smsala-api-token" class="form-label">{{ $t('smsalaApiToken') }}</label>
+        <HiddenInput id="smsala-api-token" v-model="$parent.notification.smsalaApiToken" :required="true"></HiddenInput>
+    </div>
+    <div class="mb-3">
+        <label for="smsala-from" class="form-label">{{ $t('smsalaFrom') }}</label>
+        <input id="smsala-from" v-model="$parent.notification.smsalaFrom" type="text" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="smsala-to" class="form-label">{{ $t('smsalaTo') }}</label>
+        <input id="smsala-to" v-model="$parent.notification.smsalaTo" type="text" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="smsala-message-type" class="form-label">{{ $t('SMS Type') }}</label>
+        <select id="smsala-message-type" v-model="$parent.notification.smsalaMessageType" class="form-select">
+            <option value="1">Promo</option>
+            <option value="2">Transactional</option>
+            <option value="3">OTP</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="smsala-encoding" class="form-label">{{ $t('Body Encoding') }}</label>
+        <select id="smsala-encoding" v-model="$parent.notification.smsalaMessageEncoding" class="form-select">
+            <option value="1">Default</option>
+            <option value="2">ASCII</option>
+            <option value="3">Octet</option>
+            <option value="4">Latin-1</option>
+        </select>
+    </div>
+</template>
+
+<script>
+import HiddenInput from "../HiddenInput.vue";
+
+export default {
+    components: {
+        HiddenInput,
+    },
+};
+</script>

--- a/src/components/notifications/index.js
+++ b/src/components/notifications/index.js
@@ -75,6 +75,7 @@ import SIGNL4 from "./SIGNL4.vue";
 import SendGrid from "./SendGrid.vue";
 import YZJ from "./YZJ.vue";
 import SMSPlanet from "./SMSPlanet.vue";
+import SMSala from "./SMSala.vue";
 
 /**
  * Manage all notification form.
@@ -158,6 +159,7 @@ const NotificationFormList = {
     "SendGrid": SendGrid,
     "YZJ": YZJ,
     "SMSPlanet": SMSPlanet,
+    "SMSala": SMSala,
 };
 
 export default NotificationFormList;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1098,5 +1098,8 @@
     "Phone numbers": "Phone numbers",
     "Sender name": "Sender name",
     "smsplanetNeedToApproveName": "Needs to be approved in the client panel",
+    "smsalaApiToken": "API token for the SMSala API",
+    "smsalaFrom": "Approved Sender ID",
+    "smsalaTo": "Destination Number(s)",
     "Disable URL in Notification": "Disable URL in Notification"
 }


### PR DESCRIPTION
## Summary
- add new SMSala notification provider
- expose SMSala form in frontend
- include SMSala in notification lists
- add English localisation strings

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm test` *(fails: cross-env not found)*