### PR TITLE
Add WebSocket monitor support

### DIFF
--- a/server/monitor-types/websocket.js
+++ b/server/monitor-types/websocket.js
@@ -1,0 +1,57 @@
+const { MonitorType } = require("./monitor-type");
+const { UP } = require("../../src/util");
+const WebSocket = require("ws");
+const dayjs = require("dayjs");
+
+class WebSocketMonitorType extends MonitorType {
+    name = "websocket";
+
+    /**
+     * Connect to the WebSocket server and mark the heartbeat as UP if the
+     * connection can be established.
+     * @param {Monitor} monitor monitor instance
+     * @param {Heartbeat} heartbeat heartbeat instance
+     * @param {UptimeKumaServer} _server server instance (unused)
+     * @returns {Promise<void>}
+     */
+    async check(monitor, heartbeat, _server) {
+        const startTime = dayjs().valueOf();
+        let url = monitor.url || "";
+
+        if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
+            const protocol = monitor.getIgnoreTls() ? "ws" : "wss";
+            const host = monitor.hostname || "localhost";
+            const port = monitor.port ? `:${monitor.port}` : "";
+            url = `${protocol}://${host}${port}`;
+        }
+
+        await new Promise((resolve, reject) => {
+            const ws = new WebSocket(url, {
+                rejectUnauthorized: !monitor.getIgnoreTls(),
+            });
+
+            const timeout = setTimeout(() => {
+                ws.terminate();
+                reject(new Error("timeout"));
+            }, monitor.timeout * 1000);
+
+            ws.on("open", () => {
+                clearTimeout(timeout);
+                heartbeat.ping = dayjs().valueOf() - startTime;
+                heartbeat.status = UP;
+                heartbeat.msg = "Connected";
+                ws.close();
+                resolve();
+            });
+
+            ws.on("error", (err) => {
+                clearTimeout(timeout);
+                reject(err);
+            });
+        });
+    }
+}
+
+module.exports = {
+    WebSocketMonitorType,
+};

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -118,6 +118,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["snmp"] = new SNMPMonitorType();
         UptimeKumaServer.monitorTypeList["mongodb"] = new MongodbMonitorType();
         UptimeKumaServer.monitorTypeList["rabbitmq"] = new RabbitMqMonitorType();
+        UptimeKumaServer.monitorTypeList["websocket"] = new WebSocketMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -558,4 +559,5 @@ const { GroupMonitorType } = require("./monitor-types/group");
 const { SNMPMonitorType } = require("./monitor-types/snmp");
 const { MongodbMonitorType } = require("./monitor-types/mongodb");
 const { RabbitMqMonitorType } = require("./monitor-types/rabbitmq");
+const { WebSocketMonitorType } = require("./monitor-types/websocket");
 const Monitor = require("./model/monitor");

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -18,6 +18,9 @@
                                         <option value="http">
                                             HTTP(s)
                                         </option>
+                                        <option value="websocket">
+                                            WebSocket
+                                        </option>
                                         <option value="port">
                                             TCP Port
                                         </option>
@@ -116,9 +119,9 @@
                             </div>
 
                             <!-- URL -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' " class="my-3">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' || monitor.type === 'websocket'" class="my-3">
                                 <label for="url" class="form-label">{{ $t("URL") }}</label>
-                                <input id="url" v-model="monitor.url" type="url" class="form-control" pattern="https?://.+" required data-testid="url-input">
+                                <input id="url" v-model="monitor.url" type="url" class="form-control" :pattern="monitor.type === 'websocket' ? 'wss?:\\/\\/.+' : 'https?://.+'" required data-testid="url-input">
                             </div>
 
                             <!-- gRPC URL -->
@@ -610,8 +613,8 @@
                                 <input id="retry-interval" v-model="monitor.retryInterval" type="number" class="form-control" required :min="minInterval" step="1">
                             </div>
 
-                            <!-- Timeout: HTTP / Keyword / SNMP only -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq'" class="my-3">
+                            <!-- Timeout: HTTP / Keyword / SNMP / WebSocket -->
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq' || monitor.type === 'websocket'" class="my-3">
                                 <label for="timeout" class="form-label">{{ $t("Request Timeout") }} ({{ $t("timeoutAfter", [ monitor.timeout || clampTimeout(monitor.interval) ]) }})</label>
                                 <input id="timeout" v-model="monitor.timeout" type="number" class="form-control" required min="0" step="0.1">
                             </div>
@@ -636,7 +639,7 @@
                                 </div>
                             </div>
 
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis' " class="my-3 form-check">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis' || monitor.type === 'websocket'" class="my-3 form-check">
                                 <input id="ignore-tls" v-model="monitor.ignoreTls" class="form-check-input" type="checkbox" value="">
                                 <label class="form-check-label" for="ignore-tls">
                                     {{ monitor.type === "redis" ? $t("ignoreTLSErrorGeneral") : $t("ignoreTLSError") }}


### PR DESCRIPTION
## Summary
- implement `websocket` monitor type
- register new monitor type on server
- expose WebSocket option in monitor form

## Testing
- `npm test` *(fails: cross-env not found)*