### PR TITLE
Add WebSocket monitor support

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -309,6 +309,18 @@ class Database {
                 },
                 pool: mariadbPoolConfig,
             };
+        } else if (dbConfig.type === "postgres") {
+            config = {
+                client: "pg",
+                connection: {
+                    host: dbConfig.hostname,
+                    port: dbConfig.port,
+                    user: dbConfig.username,
+                    password: dbConfig.password,
+                    database: dbConfig.dbName,
+                },
+                pool: mariadbPoolConfig,
+            };
         } else {
             throw new Error("Unknown Database type: " + dbConfig.type);
         }
@@ -341,6 +353,8 @@ class Database {
             await this.initSQLite(testMode, noLog);
         } else if (dbConfig.type.endsWith("mariadb")) {
             await this.initMariaDB();
+        } else if (dbConfig.type === "postgres") {
+            await this.initPostgres();
         }
     }
 
@@ -387,6 +401,21 @@ class Database {
             await createTables();
         } else {
             log.debug("db", "MariaDB database already exists");
+        }
+    }
+
+    /**
+     * Initialize Postgres
+     * @returns {Promise<void>}
+     */
+    static async initPostgres() {
+        log.debug("db", "Checking if Postgres database exists...");
+        let hasTable = await R.hasTable("docker_host");
+        if (!hasTable) {
+            const { createTables } = require("../db/knex_init_db");
+            await createTables();
+        } else {
+            log.debug("db", "Postgres database already exists");
         }
     }
 

--- a/server/monitor-types/websocket.js
+++ b/server/monitor-types/websocket.js
@@ -1,0 +1,57 @@
+const { MonitorType } = require("./monitor-type");
+const { UP } = require("../../src/util");
+const WebSocket = require("ws");
+const dayjs = require("dayjs");
+
+class WebSocketMonitorType extends MonitorType {
+    name = "websocket";
+
+    /**
+     * Connect to the WebSocket server and mark the heartbeat as UP if the
+     * connection can be established.
+     * @param {Monitor} monitor monitor instance
+     * @param {Heartbeat} heartbeat heartbeat instance
+     * @param {UptimeKumaServer} _server server instance (unused)
+     * @returns {Promise<void>}
+     */
+    async check(monitor, heartbeat, _server) {
+        const startTime = dayjs().valueOf();
+        let url = monitor.url || "";
+
+        if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
+            const protocol = monitor.getIgnoreTls() ? "ws" : "wss";
+            const host = monitor.hostname || "localhost";
+            const port = monitor.port ? `:${monitor.port}` : "";
+            url = `${protocol}://${host}${port}`;
+        }
+
+        await new Promise((resolve, reject) => {
+            const ws = new WebSocket(url, {
+                rejectUnauthorized: !monitor.getIgnoreTls(),
+            });
+
+            const timeout = setTimeout(() => {
+                ws.terminate();
+                reject(new Error("timeout"));
+            }, monitor.timeout * 1000);
+
+            ws.on("open", () => {
+                clearTimeout(timeout);
+                heartbeat.ping = dayjs().valueOf() - startTime;
+                heartbeat.status = UP;
+                heartbeat.msg = "Connected";
+                ws.close();
+                resolve();
+            });
+
+            ws.on("error", (err) => {
+                clearTimeout(timeout);
+                reject(err);
+            });
+        });
+    }
+}
+
+module.exports = {
+    WebSocketMonitorType,
+};

--- a/server/uptime-kuma-server.js
+++ b/server/uptime-kuma-server.js
@@ -118,6 +118,7 @@ class UptimeKumaServer {
         UptimeKumaServer.monitorTypeList["snmp"] = new SNMPMonitorType();
         UptimeKumaServer.monitorTypeList["mongodb"] = new MongodbMonitorType();
         UptimeKumaServer.monitorTypeList["rabbitmq"] = new RabbitMqMonitorType();
+        UptimeKumaServer.monitorTypeList["websocket"] = new WebSocketMonitorType();
 
         // Allow all CORS origins (polling) in development
         let cors = undefined;
@@ -558,4 +559,5 @@ const { GroupMonitorType } = require("./monitor-types/group");
 const { SNMPMonitorType } = require("./monitor-types/snmp");
 const { MongodbMonitorType } = require("./monitor-types/mongodb");
 const { RabbitMqMonitorType } = require("./monitor-types/rabbitmq");
+const { WebSocketMonitorType } = require("./monitor-types/websocket");
 const Monitor = require("./model/monitor");

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -3,6 +3,7 @@
     "setupDatabaseChooseDatabase": "Which database would you like to use?",
     "setupDatabaseEmbeddedMariaDB": "You don't need to set anything. This docker image has embedded and configured MariaDB for you automatically. Uptime Kuma will connect to this database via unix socket.",
     "setupDatabaseMariaDB": "Connect to an external MariaDB database. You need to set the database connection information.",
+    "setupDatabasePostgres": "Connect to a Supabase/PostgreSQL database. Provide the connection details.",
     "setupDatabaseSQLite": "A simple database file, recommended for small-scale deployments. Prior to v2.0.0, Uptime Kuma used SQLite as the default database.",
     "settingUpDatabaseMSG": "Setting up the database. It may take a while, please be patient.",
     "dbName": "Database Name",

--- a/src/pages/EditMonitor.vue
+++ b/src/pages/EditMonitor.vue
@@ -18,6 +18,9 @@
                                         <option value="http">
                                             HTTP(s)
                                         </option>
+                                        <option value="websocket">
+                                            WebSocket
+                                        </option>
                                         <option value="port">
                                             TCP Port
                                         </option>
@@ -116,9 +119,9 @@
                             </div>
 
                             <!-- URL -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' " class="my-3">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'real-browser' || monitor.type === 'websocket'" class="my-3">
                                 <label for="url" class="form-label">{{ $t("URL") }}</label>
-                                <input id="url" v-model="monitor.url" type="url" class="form-control" pattern="https?://.+" required data-testid="url-input">
+                                <input id="url" v-model="monitor.url" type="url" class="form-control" :pattern="monitor.type === 'websocket' ? 'wss?:\\/\\/.+' : 'https?://.+'" required data-testid="url-input">
                             </div>
 
                             <!-- gRPC URL -->
@@ -610,8 +613,8 @@
                                 <input id="retry-interval" v-model="monitor.retryInterval" type="number" class="form-control" required :min="minInterval" step="1">
                             </div>
 
-                            <!-- Timeout: HTTP / Keyword / SNMP only -->
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq'" class="my-3">
+                            <!-- Timeout: HTTP / Keyword / SNMP / WebSocket -->
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'snmp' || monitor.type === 'rabbitmq' || monitor.type === 'websocket'" class="my-3">
                                 <label for="timeout" class="form-label">{{ $t("Request Timeout") }} ({{ $t("timeoutAfter", [ monitor.timeout || clampTimeout(monitor.interval) ]) }})</label>
                                 <input id="timeout" v-model="monitor.timeout" type="number" class="form-control" required min="0" step="0.1">
                             </div>
@@ -636,7 +639,7 @@
                                 </div>
                             </div>
 
-                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis' " class="my-3 form-check">
+                            <div v-if="monitor.type === 'http' || monitor.type === 'keyword' || monitor.type === 'json-query' || monitor.type === 'redis' || monitor.type === 'websocket'" class="my-3 form-check">
                                 <input id="ignore-tls" v-model="monitor.ignoreTls" class="form-check-input" type="checkbox" value="">
                                 <label class="form-check-label" for="ignore-tls">
                                     {{ monitor.type === "redis" ? $t("ignoreTLSErrorGeneral") : $t("ignoreTLSError") }}

--- a/src/pages/SetupDatabase.vue
+++ b/src/pages/SetupDatabase.vue
@@ -47,6 +47,11 @@
                         MariaDB/MySQL
                     </label>
 
+                    <input id="btnradio4" v-model="dbConfig.type" type="radio" class="btn-check" autocomplete="off" value="postgres">
+                    <label class="btn btn-outline-primary" for="btnradio4">
+                        Supabase/Postgres
+                    </label>
+
                     <input id="btnradio1" v-model="dbConfig.type" type="radio" class="btn-check" autocomplete="off" value="sqlite">
                     <label class="btn btn-outline-primary" for="btnradio1">
                         SQLite
@@ -61,11 +66,15 @@
                     {{ $t("setupDatabaseMariaDB") }}
                 </div>
 
+                <div v-if="dbConfig.type === 'postgres'" class="mt-3 short">
+                    {{ $t("setupDatabasePostgres") }}
+                </div>
+
                 <div v-if="dbConfig.type === 'sqlite'" class="mt-3 short">
                     {{ $t("setupDatabaseSQLite") }}
                 </div>
 
-                <template v-if="dbConfig.type === 'mariadb'">
+                <template v-if="dbConfig.type === 'mariadb' || dbConfig.type === 'postgres'">
                     <div class="form-floating mt-3 short">
                         <input id="floatingInput" v-model="dbConfig.hostname" type="text" class="form-control" required>
                         <label for="floatingInput">{{ $t("Hostname") }}</label>


### PR DESCRIPTION
## Summary
- implement `websocket` monitor type
- register new monitor type on server
- expose WebSocket option in monitor form
- add PostgreSQL (Supabase) database support

## Testing
- `npm test` *(fails: cross-env not found)*