### PR TITLE
Add instructions for UI-based config

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,13 @@
+# OCPP Monitor Prototype
+
+This prototype adds a custom health check for OCPP WebSocket endpoints.
+
+- **ADR-001** documents architecture and design decisions.
+- **ocpp-probe.js** implements a minimal charge point that performs BootNotification and Heartbeat exchange. Exit code reflects health.
+- **docker-compose.yml** shows how to mount the probe when running Kuma via Docker (optional).
+- **tests/README** describes failure scenarios and how to run the probe manually.
+
+Use the provided monitor JSON example to integrate with Uptime-Kuma. Alerts trigger whenever the probe fails or misses the heartbeat.
+
+If you run Uptime-Kuma directly with `node server/server.js`, copy `custom-monitors/ocpp-probe.js` to the `custom-monitors` folder and add an **Exec** monitor in the UI. Set `WS_URL` and other parameters in the monitor's environment variable section.
+

--- a/custom-monitors/ocpp-probe.js
+++ b/custom-monitors/ocpp-probe.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+const WebSocket = require('ws');
+const { randomUUID } = require('crypto');
+let ocpp;
+try {
+    ocpp = require('ocpp-rpc');
+} catch (err) {
+    ocpp = {};
+}
+
+const {
+    WS_URL,
+    OCPP_VERSION = '1.6',
+    CHARGE_POINT_MODEL = 'kuma-probe',
+    HEARTBEAT_TIMEOUT = '30000'
+} = process.env;
+
+if (!WS_URL) {
+    console.error(JSON.stringify({ error: 'WS_URL env var not set' }));
+    process.exit(1);
+}
+
+const SUB_PROTOCOL = OCPP_VERSION.startsWith('2') ? 'ocpp2.0.1' : 'ocpp1.6';
+
+function packCall(id, action, payload) {
+    if (ocpp.packCallMessage) {
+        return JSON.stringify(ocpp.packCallMessage(id, action, payload));
+    }
+    return JSON.stringify([2, id, action, payload]);
+}
+
+function parseMessage(data) {
+    try {
+        if (ocpp.parseMessage) {
+            return ocpp.parseMessage(data);
+        }
+        return JSON.parse(data);
+    } catch (err) {
+        return null;
+    }
+}
+
+function waitForMessage(ws, id, timeout) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            ws.removeListener('message', onMessage);
+            reject(new Error('timeout'));
+        }, timeout);
+
+        function onMessage(data) {
+            const msg = parseMessage(data);
+            if (Array.isArray(msg) && msg[1] === id) {
+                clearTimeout(timer);
+                ws.removeListener('message', onMessage);
+                resolve(msg);
+            }
+        }
+
+        ws.on('message', onMessage);
+    });
+}
+
+async function run() {
+    return new Promise((resolve, reject) => {
+        const ws = new WebSocket(WS_URL, SUB_PROTOCOL);
+
+        ws.on('error', err => {
+            reject(err);
+        });
+
+        ws.on('open', async () => {
+            try {
+                const bootId = randomUUID();
+                let payload;
+                if (SUB_PROTOCOL === 'ocpp2.0.1') {
+                    payload = {
+                        chargingStation: { model: CHARGE_POINT_MODEL, vendorName: 'Kuma' },
+                        reason: 'PowerUp'
+                    };
+                } else {
+                    payload = {
+                        chargePointModel: CHARGE_POINT_MODEL,
+                        chargePointVendor: 'Kuma'
+                    };
+                }
+                const bootMsg = packCall(bootId, 'BootNotification', payload);
+                ws.send(bootMsg);
+                const bootResp = await waitForMessage(ws, bootId, parseInt(HEARTBEAT_TIMEOUT));
+                if (!bootResp[2] || bootResp[2].status !== 'Accepted') {
+                    throw new Error('boot_rejected');
+                }
+
+                const hbId = randomUUID();
+                const hbMsg = packCall(hbId, 'Heartbeat', {});
+                const sendTime = Date.now();
+                ws.send(hbMsg);
+                await waitForMessage(ws, hbId, parseInt(HEARTBEAT_TIMEOUT));
+                const rtt = Date.now() - sendTime;
+                ws.close(1000);
+                resolve(rtt);
+            } catch (err) {
+                ws.close();
+                reject(err);
+            }
+        });
+    });
+}
+
+run().then(rtt => {
+    console.log(JSON.stringify({ status: 'ok', rtt }));
+    process.exit(0);
+}).catch(err => {
+    console.error(JSON.stringify({ error: err.message }));
+    process.exit(2);
+});
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:1
+    volumes:
+      - ./data:/app/data
+      - ../custom-monitors/ocpp-probe.js:/app/custom-monitors/ocpp-probe.js:ro
+    ports:
+      - "3001:3001"
+    restart: unless-stopped

--- a/docs/ADR-001-ocpp-monitor.md
+++ b/docs/ADR-001-ocpp-monitor.md
@@ -1,0 +1,65 @@
+# ADR-001: OCPP WebSocket Monitor
+
+## Context
+Electric vehicle charge points communicate with management systems using the Open Charge Point Protocol (OCPP) over WebSocket. Uptime and latency of these WebSocket endpoints are business critical. Uptime‑Kuma currently checks TCP and HTTP but lacks an end‑to‑end OCPP health probe.
+
+## Decision
+Implement a custom monitor using Kuma's **exec** mechanism which runs a Node.js script `ocpp-probe.js`. The probe performs a TLS handshake, upgrades to WebSocket with the appropriate OCPP sub‑protocol, sends a `BootNotification` and waits for an `Accepted` response. It then exchanges a `Heartbeat` and measures round‑trip time (RTT). Any failure or timeout exits non‑zero which triggers an alert in Uptime‑Kuma.
+
+When running Kuma via Docker, a compose file can mount the script into the container so no image rebuild is required. If you run `node server/server.js` directly, place the script under `custom-monitors/` and configure an **Exec** monitor through the UI. Future work can leverage PR #5613 (*WebSocket Upgrade Test*) once merged for a native implementation.
+
+## Architecture
+```mermaid
+graph TD
+    A[Kuma Exec Monitor] --"exec ocpp-probe.js"--> B[OCPP Endpoint]
+    B --TLS--> C[TLS Handshake]
+    C --"Upgrade: websocket"--> D[WebSocket]
+    D --"[2, id, BootNotification, {...}]"--> B
+    B --"[3, id, {status:Accepted}]"--> D
+    D --Heartbeat--> B
+    B --HeartbeatResp--> D
+    D --exit code 0--> A
+    A --Alert--> E[Notification Channel]
+```
+
+*Data flow call‑outs*
+1. **TLS handshake** – validates certificates and negotiates encryption.
+2. **WebSocket upgrade** – `Sec-WebSocket-Protocol` is set to `ocpp1.6` or `ocpp2.0.1`.
+3. **OCPP exchange** – `BootNotification` followed by `Heartbeat`. RTT is logged.
+4. **Alert path** – failures propagate via Kuma's notification system (e.g. Slack).
+
+## Feasibility Scan
+- **PR #5613 – WebSocket Upgrade Test**: adds native WebSocket probing. As of this ADR the PR is open and not yet released. Using a dev build is possible but not stable.
+- **Exec / custom-script monitor**: available in current releases and widely used for custom health checks.
+
+### Decision Matrix
+| Option | Pros | Cons |
+|-------|------|------|
+|Use dev build with PR #5613|No custom script needed|Unstable, not ARM tested|
+|Custom exec monitor (this ADR)|Works on stable release, full control|Slightly more setup|
+|Upstream contribution|Long term solution, integrates with UI|Requires development and review|
+
+We choose **custom exec monitor** now and plan upstream contribution of a WebSocket‑Keyword monitor supporting sub‑protocols and JSON messages.
+
+## Monitor Configuration Example
+The same values can be entered in the **Exec Monitor** form in the UI.
+```json
+{
+  "type": "exec",
+  "name": "OCPP Heartbeat",
+  "exec": "node /app/custom-monitors/ocpp-probe.js",
+  "envs": {
+    "WS_URL": "wss://cs.example.com/centralSystem",
+    "OCPP_VERSION": "1.6",
+    "CHARGE_POINT_MODEL": "kuma-probe",
+    "HEARTBEAT_TIMEOUT": "30000"
+  },
+  "interval": 30
+}
+```
+
+## Alerting
+When the script exits with a non‑zero code, Kuma marks the monitor as down within one interval and triggers configured notifications. RTT can be exported via Prometheus using Kuma's built‑in metrics endpoint.
+
+## Status
+Accepted

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,17 @@
+# Test Plan
+
+The prototype assumes a running OCPP Central System simulator. Three failure scenarios should be exercised:
+
+1. **TCP Down** – simulator not listening. The probe should fail to connect and Kuma reports down immediately.
+2. **WebSocket Upgrade OK but Heartbeat Missing** – server accepts the socket but does not answer the Heartbeat. The probe exits after `HEARTBEAT_TIMEOUT` (~30s).
+3. **OCPP Reject** – server returns a BootNotification with status `Rejected`. The script exits non‑zero instantly.
+
+Configure monitor interval to 30 seconds so mean time to detect is below one minute.
+
+Run the probe manually (no Docker needed) with:
+```bash
+WS_URL=wss://localhost/ocpp OCPP_VERSION=1.6 node custom-monitors/ocpp-probe.js
+
+When Kuma is started with `node server/server.js`, place the script in `custom-monitors/` and add an Exec monitor via the UI.
+```
+


### PR DESCRIPTION
## Summary
- update ocpp-probe.js to optionally use `ocpp-rpc`
- clarify how to mount and configure the monitor when running Kuma directly
- document direct node usage in the summary and test plan

## Testing
- `npm test --silent` *(fails: cross-env not found)*
- `git status --short`